### PR TITLE
SLING-11073: Rename OriginalResource ViaProviderTpye to OriginalResourceType 

### DIFF
--- a/src/main/java/org/apache/sling/models/annotations/via/OriginalResourceType.java
+++ b/src/main/java/org/apache/sling/models/annotations/via/OriginalResourceType.java
@@ -20,8 +20,8 @@ import org.apache.sling.models.annotations.ViaProviderType;
 import org.osgi.annotation.versioning.ProviderType;
 
 /**
- * Marker class for using the OriginalResource @Via provider.
+ * Marker class for using the OriginalResourceType @Via provider.
  */
 @ProviderType
-public class OriginalResource implements ViaProviderType {
+public class OriginalResourceType implements ViaProviderType {
 }


### PR DESCRIPTION
In order to make it clear that the `OriginalResourceType` relates to the `ResourceSuperType` and the `ForcedResourceType` ViaProviderTypes.