### PR TITLE
SLING-11595 - Fix injectionStrategy Javadocs

### DIFF
--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/ChildResource.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/ChildResource.java
@@ -53,11 +53,15 @@ public @interface ChildResource {
     public boolean optional() default false;
 
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
-     * @return Injection strategy
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/OSGiService.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/OSGiService.java
@@ -38,7 +38,7 @@ import org.apache.sling.models.spi.injectorspecific.InjectAnnotation;
 public @interface OSGiService {
     /**
      * specifies the RFC 1960-based filter string, which is evaluated when retrieving the service. If empty string or left out, then no filtering is being performed.
-     * 
+     *
      * @see "Core Specification, section 5.5, for a description of the filter string"
      * @see <a href="http://www.ietf.org/rfc/rfc1960.txt">RFC 1960</a>
      */
@@ -53,10 +53,15 @@ public @interface OSGiService {
     public boolean optional() default false;
 
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 }

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/RequestAttribute.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/RequestAttribute.java
@@ -54,10 +54,15 @@ public @interface RequestAttribute {
     public boolean optional() default false;
 
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 }

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/ResourcePath.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/ResourcePath.java
@@ -41,7 +41,7 @@ public @interface ResourcePath {
      * Specifies the path of the resource. If not provided, the path is derived from the property name.
      */
     public String path() default "";
-    
+
     /**
      * Specifies more than one path for the resource. If not provided, a single path is derived from the property name.
      */
@@ -63,10 +63,15 @@ public @interface ResourcePath {
     public boolean optional() default false;
 
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/ScriptVariable.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/ScriptVariable.java
@@ -53,10 +53,15 @@ public @interface ScriptVariable {
     public boolean optional() default false;
 
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 }

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/Self.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/Self.java
@@ -29,7 +29,7 @@ import org.apache.sling.models.spi.injectorspecific.InjectAnnotation;
 
 /**
  * Annotation to be used on either methods, fields or constructor parameters to let Sling Models
- * inject the adaptable itself, or an object that can be adapted from it. 
+ * inject the adaptable itself, or an object that can be adapted from it.
  */
 @Target({ METHOD, FIELD, PARAMETER })
 @Retention(RUNTIME)
@@ -38,18 +38,23 @@ import org.apache.sling.models.spi.injectorspecific.InjectAnnotation;
 public @interface Self {
 
     /**
-     * If set to true, the model can be instantiated even if there is no object that can be adapted from the adaptable itself. 
+     * If set to true, the model can be instantiated even if there is no object that can be adapted from the adaptable itself.
      * Default = false.
      * @deprecated Use {@link #injectionStrategy} instead
      */
     @Deprecated
     public boolean optional() default false;
-    
+
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/SlingObject.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/SlingObject.java
@@ -91,12 +91,17 @@ public @interface SlingObject {
      */
     @Deprecated
     boolean optional() default false;
-    
+
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     public InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 

--- a/src/main/java/org/apache/sling/models/annotations/injectorspecific/ValueMapValue.java
+++ b/src/main/java/org/apache/sling/models/annotations/injectorspecific/ValueMapValue.java
@@ -53,10 +53,15 @@ public @interface ValueMapValue {
     boolean optional() default false;
 
     /**
-     * if set to REQUIRED injection is mandatory, if set to OPTIONAL injection is optional, in case of DEFAULT 
-     * the standard annotations ({@link org.apache.sling.models.annotations.Optional}, {@link org.apache.sling.models.annotations.Required}) are used.
-     * If even those are not available the default injection strategy defined on the {@link org.apache.sling.models.annotations.Model} applies.
-     * Default value = DEFAULT.
+     * Specifies the injection strategy applied to an annotated element:
+     * <ul>
+     * <li>If set to {@link InjectionStrategy#REQUIRED}, injection is mandatory.</li>
+     * <li>If set to {@link InjectionStrategy#OPTIONAL}, injection is optional.</li>
+     * <li>If set to {@link InjectionStrategy#DEFAULT} (default), the default injection strategy defined on the
+     * {@link org.apache.sling.models.annotations.Model} applies.</li>
+     * </ul>
+     * WARNING: Injection strategy is ignored if either {@link org.apache.sling.models.annotations.Optional}
+     * or {@link org.apache.sling.models.annotations.Required} is applied on the same element.
      */
     InjectionStrategy injectionStrategy() default InjectionStrategy.DEFAULT;
 


### PR DESCRIPTION
It fixes the incorrect `injectionStrategy` Javadocs.

See: https://issues.apache.org/jira/browse/SLING-11595 for more details.