### PR TITLE
SLING-12874 migrate ModelFactory to Sling API 3.x and Jakarta Servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
     </parent>
 
     <artifactId>org.apache.sling.models.api</artifactId>
-    <version>1.5.5-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>Apache Sling Models API</name>
     <description>Apache Sling Models API</description>
 
@@ -40,7 +40,7 @@
     </scm>
 
     <properties>
-        <sling.java.version>8</sling.java.version>
+        <sling.java.version>17</sling.java.version>
         <project.build.outputTimestamp>2024-07-01T12:25:41Z</project.build.outputTimestamp>
     </properties>
 
@@ -63,12 +63,18 @@
         <dependency>
             <groupId>org.apache.sling</groupId>
             <artifactId>org.apache.sling.api</artifactId>
-            <version>2.25.4</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>
             <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <version>6.0.0</version>
             <scope>provided</scope>
         </dependency>
         <!-- testing dependencies -->

--- a/src/main/java/org/apache/sling/models/factory/ModelFactory.java
+++ b/src/main/java/org/apache/sling/models/factory/ModelFactory.java
@@ -21,6 +21,7 @@ package org.apache.sling.models.factory;
 import java.util.Map;
 
 import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
@@ -67,9 +68,32 @@ public interface ModelFactory {
      * @throws InvalidModelException in case the given model type could not be validated through the model validation
      * @since 1.5.0 (Models API Bundle 1.4.4)
      * @see #getModelFromWrappedRequest(SlingHttpServletRequest, Resource, Class)
+     * @deprecated use {@link #createModelFromWrappedRequest(SlingJakartaHttpServletRequest, Resource, Class)} instead
      */
+    @Deprecated(since = "1.6.0")
     public @NotNull <T> T createModelFromWrappedRequest(
             @NotNull SlingHttpServletRequest request, @NotNull Resource resource, @NotNull Class<T> targetClass);
+
+    /**
+     * Create a wrapped request object with the specified resource and instantiates the given Sling Model class from that wrapped request. The wrapped request
+     * object will have a fresh set of script bindings so that any injected bindings references have the correct context.
+     *
+     * @param request the current request
+     * @param resource the resource to set as the wrapped request's resource
+     * @param targetClass the class to instantiate
+     * @param <T> Model type
+     * @return a new instance for the required model (never {@code null})
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     * @since 1.5.0 (Models API Bundle 1.4.4)
+     * @see #getModelFromWrappedRequest(SlingJakartaHttpServletRequest, Resource, Class)
+     */
+    public @NotNull <T> T createModelFromWrappedRequest(
+            @NotNull SlingJakartaHttpServletRequest request, @NotNull Resource resource, @NotNull Class<T> targetClass);
 
     /**
      *
@@ -117,8 +141,18 @@ public interface ModelFactory {
      *
      * @param request a request
      * @return {@code true} if a model class is mapped to the resource type
+     * @deprecated use {@link #isModelAvailableForRequest(SlingJakartaHttpServletRequest)} instead
      */
+    @Deprecated(since = "1.6.0")
     public boolean isModelAvailableForRequest(@NotNull SlingHttpServletRequest request);
+
+    /**
+     * Determine is a model class is available for the request's resource's resource type.
+     *
+     * @param request a request
+     * @return {@code true} if a model class is mapped to the resource type
+     */
+    public boolean isModelAvailableForRequest(@NotNull SlingJakartaHttpServletRequest request);
 
     /**
      * Obtain an adapted model class based on the resource type of the provided resource.
@@ -147,8 +181,26 @@ public interface ModelFactory {
      * @throws PostConstructException in case the post-construct method has thrown an exception itself
      * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
      * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     * @deprecated use {@link #getModelFromRequest(SlingJakartaHttpServletRequest)} instead
      */
+    @Deprecated(since = "1.6.0")
     public @NotNull Object getModelFromRequest(@NotNull SlingHttpServletRequest request)
+            throws MissingElementsException, InvalidAdaptableException, ModelClassException, PostConstructException,
+                    ValidationException, InvalidModelException;
+
+    /**
+     * Obtain an adapted model class based on the resource type of the request's resource.
+     *
+     * @param request a request
+     * @return an adapted model object
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     */
+    public @NotNull Object getModelFromRequest(@NotNull SlingJakartaHttpServletRequest request)
             throws MissingElementsException, InvalidAdaptableException, ModelClassException, PostConstructException,
                     ValidationException, InvalidModelException;
 
@@ -214,9 +266,37 @@ public interface ModelFactory {
      * @throws InvalidModelException in case the given model type could not be validated through the model validation
      * @throws ExportException if the export fails
      * @throws MissingExporterException if the named exporter can't be found
+     * @deprecated use {@link #exportModelForRequest(SlingJakartaHttpServletRequest, String, Class, Map)} instead
      */
+    @Deprecated(since = "1.6.0")
     public @NotNull <T> T exportModelForRequest(
             @NotNull SlingHttpServletRequest request,
+            @NotNull String exporterName,
+            @NotNull Class<T> targetClass,
+            @NotNull Map<String, String> options)
+            throws MissingElementsException, InvalidAdaptableException, ModelClassException, PostConstructException,
+                    ValidationException, InvalidModelException, ExportException, MissingExporterException;
+
+    /**
+     * Export the model object registered to the request's resource's type using the defined target class using the named exporter.
+     *
+     * @param request the request
+     * @param exporterName the exporter name
+     * @param targetClass the target class
+     * @param options any exporter options
+     * @param <T> the target class
+     * @return an instance of the target class
+     * @throws MissingElementsException in case no injector was able to inject some required values with the given types
+     * @throws InvalidAdaptableException in case the given class cannot be instantiated from the given adaptable (different adaptable on the model annotation)
+     * @throws ModelClassException in case the model could not be instantiated because model annotation was missing, reflection failed, no valid constructor was found, model was not registered as adapter factory yet, or post-construct could not be called
+     * @throws PostConstructException in case the post-construct method has thrown an exception itself
+     * @throws ValidationException in case validation could not be performed for some reason (e.g. no validation information available)
+     * @throws InvalidModelException in case the given model type could not be validated through the model validation
+     * @throws ExportException if the export fails
+     * @throws MissingExporterException if the named exporter can't be found
+     */
+    public @NotNull <T> T exportModelForRequest(
+            @NotNull SlingJakartaHttpServletRequest request,
             @NotNull String exporterName,
             @NotNull Class<T> targetClass,
             @NotNull Map<String, String> options)
@@ -234,7 +314,25 @@ public interface ModelFactory {
      * @param <T> the target adapter class
      * @return an instance of the target class or null if the adaptation could not be done
      * @since 1.4.0 (Models API Bundle 1.3.6)
+     * @deprecated use {@link #getModelFromWrappedRequest(SlingJakartaHttpServletRequest, Resource, Class)} instead
      */
+    @Deprecated(since = "1.6.0")
     public @Nullable <T> T getModelFromWrappedRequest(
             @NotNull SlingHttpServletRequest request, @NotNull Resource resource, @NotNull Class<T> targetClass);
+
+    /**
+     * Create a wrapped request object with the specified resource and (try to) adapt the request object into the specified class. The wrapped request
+     * object will have a fresh set of script bindings so that any injected bindings references have the correct context.
+     * Consider using {@link #createModelFromWrappedRequest(SlingHttpServletRequest, Resource, Class)} instead to get exceptions propagated which may occur when trying to create the model.
+     *
+     * @param request the current request
+     * @param resource the resource to set as the wrapped request's resource
+     * @param targetClass the target adapter class
+     * @param <T> the target adapter class
+     * @return an instance of the target class or null if the adaptation could not be done
+     * @since 1.4.0 (Models API Bundle 1.3.6)
+     *
+     */
+    public @Nullable <T> T getModelFromWrappedRequest(
+            @NotNull SlingJakartaHttpServletRequest request, @NotNull Resource resource, @NotNull Class<T> targetClass);
 }

--- a/src/main/java/org/apache/sling/models/factory/ModelFactory.java
+++ b/src/main/java/org/apache/sling/models/factory/ModelFactory.java
@@ -20,7 +20,6 @@ package org.apache.sling.models.factory;
 
 import java.util.Map;
 
-import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingJakartaHttpServletRequest;
 import org.apache.sling.api.resource.Resource;
 import org.jetbrains.annotations.NotNull;
@@ -72,7 +71,9 @@ public interface ModelFactory {
      */
     @Deprecated(since = "1.6.0")
     public @NotNull <T> T createModelFromWrappedRequest(
-            @NotNull SlingHttpServletRequest request, @NotNull Resource resource, @NotNull Class<T> targetClass);
+            @NotNull org.apache.sling.api.SlingHttpServletRequest request,
+            @NotNull Resource resource,
+            @NotNull Class<T> targetClass);
 
     /**
      * Create a wrapped request object with the specified resource and instantiates the given Sling Model class from that wrapped request. The wrapped request
@@ -144,7 +145,7 @@ public interface ModelFactory {
      * @deprecated use {@link #isModelAvailableForRequest(SlingJakartaHttpServletRequest)} instead
      */
     @Deprecated(since = "1.6.0")
-    public boolean isModelAvailableForRequest(@NotNull SlingHttpServletRequest request);
+    public boolean isModelAvailableForRequest(@NotNull org.apache.sling.api.SlingHttpServletRequest request);
 
     /**
      * Determine is a model class is available for the request's resource's resource type.
@@ -184,7 +185,7 @@ public interface ModelFactory {
      * @deprecated use {@link #getModelFromRequest(SlingJakartaHttpServletRequest)} instead
      */
     @Deprecated(since = "1.6.0")
-    public @NotNull Object getModelFromRequest(@NotNull SlingHttpServletRequest request)
+    public @NotNull Object getModelFromRequest(@NotNull org.apache.sling.api.SlingHttpServletRequest request)
             throws MissingElementsException, InvalidAdaptableException, ModelClassException, PostConstructException,
                     ValidationException, InvalidModelException;
 
@@ -270,7 +271,7 @@ public interface ModelFactory {
      */
     @Deprecated(since = "1.6.0")
     public @NotNull <T> T exportModelForRequest(
-            @NotNull SlingHttpServletRequest request,
+            @NotNull org.apache.sling.api.SlingHttpServletRequest request,
             @NotNull String exporterName,
             @NotNull Class<T> targetClass,
             @NotNull Map<String, String> options)
@@ -318,7 +319,9 @@ public interface ModelFactory {
      */
     @Deprecated(since = "1.6.0")
     public @Nullable <T> T getModelFromWrappedRequest(
-            @NotNull SlingHttpServletRequest request, @NotNull Resource resource, @NotNull Class<T> targetClass);
+            @NotNull org.apache.sling.api.SlingHttpServletRequest request,
+            @NotNull Resource resource,
+            @NotNull Class<T> targetClass);
 
     /**
      * Create a wrapped request object with the specified resource and (try to) adapt the request object into the specified class. The wrapped request

--- a/src/main/java/org/apache/sling/models/factory/ModelFactory.java
+++ b/src/main/java/org/apache/sling/models/factory/ModelFactory.java
@@ -112,7 +112,7 @@ public interface ModelFactory {
      * @see org.apache.sling.models.annotations.Model
      * @deprecated Use {@link #isModelClass(Class)} instead!
      */
-    @Deprecated
+    @Deprecated(since = "1.1.0")
     public boolean isModelClass(@NotNull Object adaptable, @NotNull Class<?> type);
 
     /**

--- a/src/main/java/org/apache/sling/models/factory/package-info.java
+++ b/src/main/java/org/apache/sling/models/factory/package-info.java
@@ -14,7 +14,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-@Version("1.5.0")
+@Version("1.6.0")
 package org.apache.sling.models.factory;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
bump bundle major version to 2.0.0
bump minimum java version to 17
bump sling.api dependency to 3.0.0
clone the ModelFactory methods that use SlingHttpServletRequest parameters to use SlingJakartaHttpServletRequest instead
deprecate the ModelFactory methods that used SlingHttpServletRequest